### PR TITLE
tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,13 @@ byteorder = "1"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 trackable = "0.2"
-tokio = {version = "1.0", features = ["io-util"]}
-pin-project = "1"
+tokio = { version = "1.0", features = ["io-util"], optional = true }
+pin-project = { version = "1", optional = true }
 
 [features]
 bincode_codec = ["serde", "bincode"]
 json_codec = ["serde", "serde_json"]
+tokio-async = ["tokio", "pin-project"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ byteorder = "1"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 trackable = "0.2"
+tokio = {version = "1.0", features = ["io-util"]}
+pin-project = "1"
 
 [features]
 bincode_codec = ["serde", "bincode"]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -199,7 +199,7 @@ pub trait DecodeExt: Decode + Sized {
     ///   [0] at src/bytes.rs:152
     ///   [1] at src/fixnum.rs:198
     ///   [2] at src/decode.rs:10 -- oops!
-    ///   [3] at src/io.rs:43
+    ///   [3] at src/io.rs:45
     ///   [4] at src/decode.rs:14\n");
     /// ```
     fn map_err<E, F>(self, f: F) -> MapErr<Self, E, F>

--- a/src/io.rs
+++ b/src/io.rs
@@ -117,10 +117,10 @@ impl StreamState {
 /// Read buffer.
 #[derive(Debug)]
 pub struct ReadBuf<B> {
-    inner: B,
-    head: usize,
-    tail: usize,
-    stream_state: StreamState,
+    pub(crate) inner: B,
+    pub(crate) head: usize,
+    pub(crate) tail: usize,
+    pub(crate) stream_state: StreamState,
 }
 impl<B: AsRef<[u8]> + AsMut<[u8]>> ReadBuf<B> {
     /// Makes a new `ReadBuf` instance.
@@ -232,10 +232,10 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Read for ReadBuf<B> {
 /// Write buffer.
 #[derive(Debug)]
 pub struct WriteBuf<B> {
-    inner: B,
-    head: usize,
-    tail: usize,
-    stream_state: StreamState,
+    pub(crate) inner: B,
+    pub(crate) head: usize,
+    pub(crate) tail: usize,
+    pub(crate) stream_state: StreamState,
 }
 impl<B: AsRef<[u8]> + AsMut<[u8]>> WriteBuf<B> {
     /// Makes a new `WriteBuf` instance.

--- a/src/io.rs
+++ b/src/io.rs
@@ -362,15 +362,6 @@ pub struct BufferedIo<T> {
     pub(crate) wbuf: WriteBuf<Vec<u8>>,
 }
 impl<T: Read + Write> BufferedIo<T> {
-    /// Makes a new `BufferedIo` instance.
-    pub fn new(stream: T, read_buf_size: usize, write_buf_size: usize) -> Self {
-        BufferedIo {
-            stream,
-            rbuf: ReadBuf::new(vec![0; read_buf_size]),
-            wbuf: WriteBuf::new(vec![0; write_buf_size]),
-        }
-    }
-
     /// Executes an I/O operation on the inner stream.
     ///
     /// "I/O operation" means "filling the read buffer" and "flushing the write buffer".
@@ -382,6 +373,15 @@ impl<T: Read + Write> BufferedIo<T> {
 }
 
 impl<T> BufferedIo<T> {
+    /// Makes a new `BufferedIo` instance.
+    pub fn new(stream: T, read_buf_size: usize, write_buf_size: usize) -> Self {
+        BufferedIo {
+            stream,
+            rbuf: ReadBuf::new(vec![0; read_buf_size]),
+            wbuf: WriteBuf::new(vec![0; write_buf_size]),
+        }
+    }
+
     /// Returns `true` if the inner stream reaches EOS, otherwise `false`.
     pub fn is_eos(&self) -> bool {
         self.rbuf.stream_state().is_eos() || self.wbuf.stream_state().is_eos()

--- a/src/io_async.rs
+++ b/src/io_async.rs
@@ -1,9 +1,8 @@
 //! I/O (i.e., `Read` and `Write` traits) related module.
-use crate::io::{ReadBuf, StreamState, WriteBuf};
+use crate::io::{BufferedIo, ReadBuf, StreamState, WriteBuf};
 use crate::{Error, Result};
 use core::pin::Pin;
 use core::task::{Context, Poll as Poll03};
-use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 impl<B: AsRef<[u8]> + AsMut<[u8]>> ReadBuf<B> {
@@ -89,140 +88,14 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> WriteBuf<B> {
     }
 }
 
-/// Buffered I/O stream.
-#[pin_project]
-#[derive(Debug)]
-pub struct BufferedIo<T> {
-    #[pin]
-    stream: T,
-    rbuf: ReadBuf<Vec<u8>>,
-    wbuf: WriteBuf<Vec<u8>>,
-}
 impl<T: AsyncRead + AsyncWrite> BufferedIo<T> {
-    /// Makes a new `BufferedIo` instance.
-    pub fn new(stream: T, read_buf_size: usize, write_buf_size: usize) -> Self {
-        BufferedIo {
-            stream,
-            rbuf: ReadBuf::new(vec![0; read_buf_size]),
-            wbuf: WriteBuf::new(vec![0; write_buf_size]),
-        }
-    }
-
     /// Executes an I/O operation on the inner stream.
     ///
     /// "I/O operation" means "filling the read buffer" and "flushing the write buffer".
-    pub fn execute_io(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Result<()> {
+    pub fn execute_io_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Result<()> {
         let mut this = self.project();
         track!(this.rbuf.poll_fill(this.stream.as_mut(), cx))?;
         track!(this.wbuf.poll_flush(this.stream.as_mut(), cx))?;
         Ok(())
-    }
-
-    /// Returns `true` if the inner stream reaches EOS, otherwise `false`.
-    pub fn is_eos(&self) -> bool {
-        self.rbuf.stream_state().is_eos() || self.wbuf.stream_state().is_eos()
-    }
-
-    /// Returns `true` if the previous I/O operation on the inner stream would block, otherwise `false`.
-    pub fn would_block(&self) -> bool {
-        self.rbuf.stream_state().would_block()
-            && (self.wbuf.is_empty() || self.wbuf.stream_state().would_block())
-    }
-
-    /// Returns a reference to the read buffer of the instance.
-    pub fn read_buf_ref(&self) -> &ReadBuf<Vec<u8>> {
-        &self.rbuf
-    }
-
-    /// Returns a mutable reference to the read buffer of the instance.
-    pub fn read_buf_mut(&mut self) -> &mut ReadBuf<Vec<u8>> {
-        &mut self.rbuf
-    }
-
-    /// Returns a reference to the write buffer of the instance.
-    pub fn write_buf_ref(&self) -> &WriteBuf<Vec<u8>> {
-        &self.wbuf
-    }
-
-    /// Returns a mutable reference to the write buffer of the instance.
-    pub fn write_buf_mut(&mut self) -> &mut WriteBuf<Vec<u8>> {
-        &mut self.wbuf
-    }
-
-    /// Returns a reference to the inner stream of the instance.
-    pub fn stream_ref(&self) -> &T {
-        &self.stream
-    }
-
-    /// Returns a mutable reference to the inner stream of the instance.
-    pub fn stream_mut(&mut self) -> &mut T {
-        &mut self.stream
-    }
-
-    /// Takes ownership of the instance, and returns the inner stream.
-    pub fn into_stream(self) -> T {
-        self.stream
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::io::{Read, Write};
-
-    use super::*;
-    use bytes::{Utf8Decoder, Utf8Encoder};
-    use EncodeExt;
-
-    #[test]
-    fn decode_from_read_buf_works() {
-        let mut buf = ReadBuf::new(vec![0; 1024]);
-        track_try_unwrap!(buf.fill(b"foo".as_ref()));
-        assert_eq!(buf.len(), 3);
-        assert_eq!(buf.stream_state(), StreamState::Eos);
-
-        let mut decoder = Utf8Decoder::new();
-        track_try_unwrap!(decoder.decode_from_read_buf(&mut buf));
-        assert_eq!(track_try_unwrap!(decoder.finish_decoding()), "foo");
-    }
-
-    #[test]
-    fn read_from_read_buf_works() {
-        let mut rbuf = ReadBuf::new(vec![0; 1024]);
-        track_try_unwrap!(rbuf.fill(b"foo".as_ref()));
-        assert_eq!(rbuf.len(), 3);
-        assert_eq!(rbuf.stream_state(), StreamState::Eos);
-
-        let mut buf = Vec::new();
-        rbuf.read_to_end(&mut buf).unwrap();
-        assert_eq!(buf, b"foo");
-        assert_eq!(rbuf.len(), 0);
-    }
-
-    #[test]
-    fn encode_to_write_buf_works() {
-        let mut encoder = track_try_unwrap!(Utf8Encoder::with_item("foo"));
-
-        let mut buf = WriteBuf::new(vec![0; 1024]);
-        track_try_unwrap!(encoder.encode_to_write_buf(&mut buf));
-        assert_eq!(buf.len(), 3);
-
-        let mut v = Vec::new();
-        track_try_unwrap!(buf.flush(&mut v));
-        assert_eq!(buf.len(), 0);
-        assert_eq!(buf.stream_state(), StreamState::Normal);
-        assert_eq!(v, b"foo");
-    }
-
-    #[test]
-    fn write_to_write_buf_works() {
-        let mut buf = WriteBuf::new(vec![0; 1024]);
-        buf.write_all(b"foo").unwrap();
-        assert_eq!(buf.len(), 3);
-
-        let mut v = Vec::new();
-        track_try_unwrap!(buf.flush(&mut v));
-        assert_eq!(buf.len(), 0);
-        assert_eq!(buf.stream_state(), StreamState::Normal);
-        assert_eq!(v, b"foo");
     }
 }

--- a/src/io_async.rs
+++ b/src/io_async.rs
@@ -1,0 +1,228 @@
+//! I/O (i.e., `Read` and `Write` traits) related module.
+use crate::io::{ReadBuf, StreamState, WriteBuf};
+use crate::{Error, Result};
+use core::pin::Pin;
+use core::task::{Context, Poll as Poll03};
+use pin_project::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+impl<B: AsRef<[u8]> + AsMut<[u8]>> ReadBuf<B> {
+    /// Fills the read buffer by reading bytes from the given reader.
+    ///
+    /// The fill process continues until one of the following condition is satisfied:
+    /// - The read buffer became full
+    /// - A read operation returned a `WouldBlock` error
+    /// - The input stream has reached EOS
+    pub fn poll_fill<R: AsyncRead>(
+        self: &mut Self,
+        mut reader: Pin<&mut R>,
+        cx: &mut Context<'_>,
+    ) -> Result<()> {
+        while !self.is_full() {
+            let mut buffer = tokio::io::ReadBuf::new(&mut self.inner.as_mut()[self.tail..]);
+            match reader.as_mut().poll_read(cx, &mut buffer) {
+                Poll03::Pending => {
+                    self.stream_state = StreamState::WouldBlock;
+                    break;
+                }
+                Poll03::Ready(Ok(())) => {
+                    let size = buffer.filled().len();
+                    if size == 0 {
+                        self.stream_state = StreamState::Eos;
+                        break;
+                    }
+                    self.stream_state = StreamState::Normal;
+                    self.tail += size;
+                }
+                Poll03::Ready(Err(e)) => {
+                    self.stream_state = StreamState::Error;
+                    return Err(track!(Error::from(e)));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<B: AsRef<[u8]> + AsMut<[u8]>> WriteBuf<B> {
+    /// Writes the encoded bytes contained in this buffer to the given writer.
+    ///
+    /// The written bytes will be removed from the buffer.
+    ///
+    /// The flush process continues until one of the following condition is satisfied:
+    /// - The write buffer became empty
+    /// - A write operation returned a `WouldBlock` error
+    /// - The output stream has reached EOS
+    pub fn poll_flush<W: AsyncWrite>(
+        &mut self,
+        mut writer: Pin<&mut W>,
+        cx: &mut Context<'_>,
+    ) -> Result<()> {
+        while !self.is_empty() {
+            match writer
+                .as_mut()
+                .poll_write(cx, &self.inner.as_ref()[self.head..self.tail])
+            {
+                Poll03::Ready(Err(e)) => {
+                    self.stream_state = StreamState::Error;
+                    return Err(track!(Error::from(e)));
+                }
+                Poll03::Ready(Ok(0)) => {
+                    self.stream_state = StreamState::Eos;
+                    break;
+                }
+                Poll03::Ready(Ok(size)) => {
+                    self.stream_state = StreamState::Normal;
+                    self.head += size;
+                    if self.head == self.tail {
+                        self.head = 0;
+                        self.tail = 0;
+                    }
+                }
+                Poll03::Pending => {
+                    self.stream_state = StreamState::WouldBlock;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Buffered I/O stream.
+#[pin_project]
+#[derive(Debug)]
+pub struct BufferedIo<T> {
+    #[pin]
+    stream: T,
+    rbuf: ReadBuf<Vec<u8>>,
+    wbuf: WriteBuf<Vec<u8>>,
+}
+impl<T: AsyncRead + AsyncWrite> BufferedIo<T> {
+    /// Makes a new `BufferedIo` instance.
+    pub fn new(stream: T, read_buf_size: usize, write_buf_size: usize) -> Self {
+        BufferedIo {
+            stream,
+            rbuf: ReadBuf::new(vec![0; read_buf_size]),
+            wbuf: WriteBuf::new(vec![0; write_buf_size]),
+        }
+    }
+
+    /// Executes an I/O operation on the inner stream.
+    ///
+    /// "I/O operation" means "filling the read buffer" and "flushing the write buffer".
+    pub fn execute_io(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Result<()> {
+        let mut this = self.project();
+        track!(this.rbuf.poll_fill(this.stream.as_mut(), cx))?;
+        track!(this.wbuf.poll_flush(this.stream.as_mut(), cx))?;
+        Ok(())
+    }
+
+    /// Returns `true` if the inner stream reaches EOS, otherwise `false`.
+    pub fn is_eos(&self) -> bool {
+        self.rbuf.stream_state().is_eos() || self.wbuf.stream_state().is_eos()
+    }
+
+    /// Returns `true` if the previous I/O operation on the inner stream would block, otherwise `false`.
+    pub fn would_block(&self) -> bool {
+        self.rbuf.stream_state().would_block()
+            && (self.wbuf.is_empty() || self.wbuf.stream_state().would_block())
+    }
+
+    /// Returns a reference to the read buffer of the instance.
+    pub fn read_buf_ref(&self) -> &ReadBuf<Vec<u8>> {
+        &self.rbuf
+    }
+
+    /// Returns a mutable reference to the read buffer of the instance.
+    pub fn read_buf_mut(&mut self) -> &mut ReadBuf<Vec<u8>> {
+        &mut self.rbuf
+    }
+
+    /// Returns a reference to the write buffer of the instance.
+    pub fn write_buf_ref(&self) -> &WriteBuf<Vec<u8>> {
+        &self.wbuf
+    }
+
+    /// Returns a mutable reference to the write buffer of the instance.
+    pub fn write_buf_mut(&mut self) -> &mut WriteBuf<Vec<u8>> {
+        &mut self.wbuf
+    }
+
+    /// Returns a reference to the inner stream of the instance.
+    pub fn stream_ref(&self) -> &T {
+        &self.stream
+    }
+
+    /// Returns a mutable reference to the inner stream of the instance.
+    pub fn stream_mut(&mut self) -> &mut T {
+        &mut self.stream
+    }
+
+    /// Takes ownership of the instance, and returns the inner stream.
+    pub fn into_stream(self) -> T {
+        self.stream
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::{Read, Write};
+
+    use super::*;
+    use bytes::{Utf8Decoder, Utf8Encoder};
+    use EncodeExt;
+
+    #[test]
+    fn decode_from_read_buf_works() {
+        let mut buf = ReadBuf::new(vec![0; 1024]);
+        track_try_unwrap!(buf.fill(b"foo".as_ref()));
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf.stream_state(), StreamState::Eos);
+
+        let mut decoder = Utf8Decoder::new();
+        track_try_unwrap!(decoder.decode_from_read_buf(&mut buf));
+        assert_eq!(track_try_unwrap!(decoder.finish_decoding()), "foo");
+    }
+
+    #[test]
+    fn read_from_read_buf_works() {
+        let mut rbuf = ReadBuf::new(vec![0; 1024]);
+        track_try_unwrap!(rbuf.fill(b"foo".as_ref()));
+        assert_eq!(rbuf.len(), 3);
+        assert_eq!(rbuf.stream_state(), StreamState::Eos);
+
+        let mut buf = Vec::new();
+        rbuf.read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, b"foo");
+        assert_eq!(rbuf.len(), 0);
+    }
+
+    #[test]
+    fn encode_to_write_buf_works() {
+        let mut encoder = track_try_unwrap!(Utf8Encoder::with_item("foo"));
+
+        let mut buf = WriteBuf::new(vec![0; 1024]);
+        track_try_unwrap!(encoder.encode_to_write_buf(&mut buf));
+        assert_eq!(buf.len(), 3);
+
+        let mut v = Vec::new();
+        track_try_unwrap!(buf.flush(&mut v));
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.stream_state(), StreamState::Normal);
+        assert_eq!(v, b"foo");
+    }
+
+    #[test]
+    fn write_to_write_buf_works() {
+        let mut buf = WriteBuf::new(vec![0; 1024]);
+        buf.write_all(b"foo").unwrap();
+        assert_eq!(buf.len(), 3);
+
+        let mut v = Vec::new();
+        track_try_unwrap!(buf.flush(&mut v));
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.stream_state(), StreamState::Normal);
+        assert_eq!(v, b"foo");
+    }
+}

--- a/src/io_async.rs
+++ b/src/io_async.rs
@@ -2,7 +2,7 @@
 use crate::io::{BufferedIo, ReadBuf, StreamState, WriteBuf};
 use crate::{Error, Result};
 use core::pin::Pin;
-use core::task::{Context, Poll as Poll03};
+use core::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 impl<B: AsRef<[u8]> + AsMut<[u8]>> ReadBuf<B> {
@@ -16,30 +16,30 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> ReadBuf<B> {
         &mut self,
         mut reader: Pin<&mut R>,
         cx: &mut Context<'_>,
-    ) -> Poll03<Result<()>> {
+    ) -> Poll<Result<()>> {
         while !self.is_full() {
             let mut buffer = tokio::io::ReadBuf::new(&mut self.inner.as_mut()[self.tail..]);
             match reader.as_mut().poll_read(cx, &mut buffer) {
-                Poll03::Pending => {
+                Poll::Pending => {
                     self.stream_state = StreamState::WouldBlock;
-                    return Poll03::Pending;
+                    return Poll::Pending;
                 }
-                Poll03::Ready(Ok(())) => {
+                Poll::Ready(Ok(())) => {
                     let size = buffer.filled().len();
                     if size == 0 {
                         self.stream_state = StreamState::Eos;
-                        return Poll03::Ready(Ok(()));
+                        return Poll::Ready(Ok(()));
                     }
                     self.stream_state = StreamState::Normal;
                     self.tail += size;
                 }
-                Poll03::Ready(Err(e)) => {
+                Poll::Ready(Err(e)) => {
                     self.stream_state = StreamState::Error;
-                    return Poll03::Ready(Err(track!(Error::from(e))));
+                    return Poll::Ready(Err(track!(Error::from(e))));
                 }
             }
         }
-        Poll03::Ready(Ok(()))
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -56,22 +56,22 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> WriteBuf<B> {
         &mut self,
         mut writer: Pin<&mut W>,
         cx: &mut Context<'_>,
-    ) -> Poll03<Result<()>> {
+    ) -> Poll<Result<()>> {
         while !self.is_empty() {
             match writer
                 .as_mut()
                 .poll_write(cx, &self.inner.as_ref()[self.head..self.tail])
             {
-                Poll03::Ready(Err(e)) => {
+                Poll::Ready(Err(e)) => {
                     self.stream_state = StreamState::Error;
-                    return Poll03::Ready(Err(track!(Error::from(e))));
+                    return Poll::Ready(Err(track!(Error::from(e))));
                 }
-                Poll03::Ready(Ok(0)) => {
+                Poll::Ready(Ok(0)) => {
                     self.stream_state = StreamState::Eos;
                     // stream is closed. No need to wake up this future :)
-                    return Poll03::Ready(Ok(()));
+                    return Poll::Ready(Ok(()));
                 }
-                Poll03::Ready(Ok(size)) => {
+                Poll::Ready(Ok(size)) => {
                     self.stream_state = StreamState::Normal;
                     self.head += size;
                     if self.head == self.tail {
@@ -79,15 +79,15 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> WriteBuf<B> {
                         self.tail = 0;
                     }
                 }
-                Poll03::Pending => {
+                Poll::Pending => {
                     self.stream_state = StreamState::WouldBlock;
-                    return Poll03::Pending;
+                    return Poll::Pending;
                 }
             }
         }
         // Now the buffer is empty. Because the returned value is not Poll::Pending,
         // it is *the caller*'s responsibility to ensure this future is woken up.
-        Poll03::Ready(Ok(()))
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -95,22 +95,25 @@ impl<T: AsyncRead + AsyncWrite> BufferedIo<T> {
     /// Executes an I/O operation on the inner stream.
     ///
     /// "I/O operation" means "filling the read buffer" and "flushing the write buffer".
-    pub fn execute_io_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll03<Result<()>> {
+    /// This function returns Poll::Pending when both rbuf and wbuf are not ready for I/O operations.
+    pub fn execute_io_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let mut this = self.project();
         let rresult = this.rbuf.poll_fill(this.stream.as_mut(), cx);
         let wresult = this.wbuf.poll_flush(this.stream.as_mut(), cx);
-        if let (&Poll03::Pending, &Poll03::Pending) = (&rresult, &wresult) {
-            // rbuf 側と wbuf 側のどちらの準備ができても、この future は呼び起こされる。
-            return Poll03::Pending;
+        if let (&Poll::Pending, &Poll::Pending) = (&rresult, &wresult) {
+            // This future will be polled again when either rbuf or wbuf is ready.
+            return Poll::Pending;
         }
-        if let Poll03::Ready(rresult) = rresult {
+        if let Poll::Ready(rresult) = rresult {
             track!(rresult)?;
         }
-        if let Poll03::Ready(wresult) = wresult {
+        if let Poll::Ready(wresult) = wresult {
             track!(wresult)?;
         }
-        // rbuf 側と wbuf 側のどちらも Poll::Pending を返す状態でないと、この future が呼び起こされる保証がない。
-        // Ready を返して、これの呼び出し側にループなり呼び起こしの確約なりをしてもらう必要がある。
-        Poll03::Ready(Ok(()))
+
+        // If at least one of rbuf or wbuf returns Poll::Ready,
+        // there's no guarantee that the waker is signaled at some point.
+        // Poll::Ready here means it's the caller's responsibility to ensure the waker is signaled later.
+        Poll::Ready(Ok(()))
     }
 }

--- a/src/io_async.rs
+++ b/src/io_async.rs
@@ -13,7 +13,7 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> ReadBuf<B> {
     /// - A read operation returned a `WouldBlock` error
     /// - The input stream has reached EOS
     pub fn poll_fill<R: AsyncRead>(
-        self: &mut Self,
+        &mut self,
         mut reader: Pin<&mut R>,
         cx: &mut Context<'_>,
     ) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod bytes;
 pub mod combinator;
 pub mod fixnum;
 pub mod io;
+#[cfg(feature = "tokio-async")]
 pub mod io_async;
 #[cfg(feature = "json_codec")]
 pub mod json_codec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod bytes;
 pub mod combinator;
 pub mod fixnum;
 pub mod io;
+pub mod io_async;
 #[cfg(feature = "json_codec")]
 pub mod json_codec;
 pub mod marker;


### PR DESCRIPTION
This PR adds `tokio`-based future support. You can enable the functionality by adding `features = ["tokio-async"]` to the dependency.

Example of how to use: https://github.com/sile/fibers_http_server/compare/master...koba-e964:tmp/tokio-1.0

The newly added function `execute_io_poll` is called [here](https://github.com/sile/fibers_http_server/compare/master...koba-e964:tmp/tokio-1.0#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afR176).

The correctness of this change is not fully confirmed (i.e. `frugalos` with this change is not confirmed to work properly.)