### PR TITLE
Bump `trackable` to v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bincode = { version = "1", optional = true }
 byteorder = "1"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-trackable = "0.2"
+trackable = "1"
 tokio = { version = "1.0", features = ["io-util"], optional = true }
 pin-project = { version = "1", optional = true }
 


### PR DESCRIPTION
Bumps the `trackable` dependency to version 1. Unfortunately, I believe this is technically a breaking change because the version of `trackable` is exposed in various `From` impls, for example here: https://github.com/sile/bytecodec/blob/6f71222f535118571160bd2695e323bec78fd158/src/error.rs#L7-L11